### PR TITLE
fix(page): Pages as default function exported

### DIFF
--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -1,3 +1,5 @@
 export default function Page() {
-    return (<p>Dashboard Page {`>`} Invoices</p>)
+    return (
+        <p>Dashboard Page {`>`} Invoices</p>
+    )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,3 @@
-
-
 export default function Page() {
     return (<p>Dashboard Page</p>)
 }

--- a/app/ui/dashboard/page.tsx
+++ b/app/ui/dashboard/page.tsx
@@ -1,5 +1,3 @@
-
-
 export default function Page() {
     return (<>Page Dashboard</>)
 }


### PR DESCRIPTION
# DEFAULT FUNCTION EXPORT INSTEAD TO CONST

## INSTEAD TO DO THIS

````tsx
// instead to
const Page = () => {
    return (
        <p>Content</p>
    )
}

export default Page;
````

## IT SHOULD TO BE LIKE THIS
````tsx
// Should to be
export default function Page() {
    return (
        <p>Content</p>
    )
}
````

- [X] app/dashboard/page.tsx
- [X] app/dashboard/customers/page.tsx
- [X] app/dashboard/invoices/page.tsx